### PR TITLE
Fix path for license checker ignore

### DIFF
--- a/test
+++ b/test
@@ -77,7 +77,7 @@ for path in $FMT; do
 done
 
 echo "Checking for license header..."
-licRes=$(for file in $(find . -type f -iname '*.go' ! -path './Godeps/*'); do
+licRes=$(for file in $(find . -type f -iname '*.go' ! -path './vendor/*'); do
 		head -n3 "${file}" | grep -Eq "(Copyright|generated|GENERATED)" || echo -e "  ${file}"
 	done;)
 if [ -n "${licRes}" ]; then


### PR DESCRIPTION
Introduced by #1, now `./test` fails with message

```
license header checking failed: vendor/*
```

Need to just fix path
