### PR TITLE
Pass tls config to store

### DIFF
--- a/cmd/keeper/keeper.go
+++ b/cmd/keeper/keeper.go
@@ -60,6 +60,9 @@ type config struct {
 	id                      string
 	storeBackend            string
 	storeEndpoints          string
+	storeCertFile           string
+	storeKeyFile            string
+	storeCACertFile         string
 	dataDir                 string
 	clusterName             string
 	listenAddress           string
@@ -90,6 +93,9 @@ func init() {
 	cmdKeeper.PersistentFlags().StringVar(&cfg.id, "id", "", "keeper id (must be unique in the cluster and can contain only lower-case letters, numbers and the underscore character). If not provided a random id will be generated.")
 	cmdKeeper.PersistentFlags().StringVar(&cfg.storeBackend, "store-backend", "", "store backend type (etcd or consul)")
 	cmdKeeper.PersistentFlags().StringVar(&cfg.storeEndpoints, "store-endpoints", "", "a comma-delimited list of store endpoints (defaults: 127.0.0.1:2379 for etcd, 127.0.0.1:8500 for consul)")
+	cmdKeeper.PersistentFlags().StringVar(&cfg.storeCertFile, "store-cert", "", "path to the client server TLS cert file")
+	cmdKeeper.PersistentFlags().StringVar(&cfg.storeKeyFile, "store-key", "", "path to the client server TLS key file")
+	cmdKeeper.PersistentFlags().StringVar(&cfg.storeCACertFile, "store-cacert", "", "path to the client server TLS trusted CA key file")
 	cmdKeeper.PersistentFlags().StringVar(&cfg.dataDir, "data-dir", "", "data directory")
 	cmdKeeper.PersistentFlags().StringVar(&cfg.clusterName, "cluster-name", "", "cluster name")
 	cmdKeeper.PersistentFlags().StringVar(&cfg.listenAddress, "listen-address", "localhost", "keeper listening address")
@@ -245,7 +251,13 @@ type PostgresKeeper struct {
 func NewPostgresKeeper(id string, cfg *config, stop chan bool, end chan error) (*PostgresKeeper, error) {
 	storePath := filepath.Join(common.StoreBasePath, cfg.clusterName)
 
-	kvstore, err := store.NewStore(store.Backend(cfg.storeBackend), cfg.storeEndpoints)
+	kvstore, err := store.NewStore(
+		store.Backend(cfg.storeBackend),
+		cfg.storeEndpoints,
+		cfg.storeCertFile,
+		cfg.storeKeyFile,
+		cfg.storeCACertFile,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create store: %v", err)
 	}

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -46,13 +46,16 @@ var cmdProxy = &cobra.Command{
 }
 
 type config struct {
-	storeBackend   string
-	storeEndpoints string
-	clusterName    string
-	listenAddress  string
-	port           string
-	stopListening  bool
-	debug          bool
+	storeBackend    string
+	storeEndpoints  string
+	storeCertFile   string
+	storeKeyFile    string
+	storeCACertFile string
+	clusterName     string
+	listenAddress   string
+	port            string
+	stopListening   bool
+	debug           bool
 }
 
 var cfg config
@@ -60,6 +63,9 @@ var cfg config
 func init() {
 	cmdProxy.PersistentFlags().StringVar(&cfg.storeBackend, "store-backend", "", "store backend type (etcd or consul)")
 	cmdProxy.PersistentFlags().StringVar(&cfg.storeEndpoints, "store-endpoints", "", "a comma-delimited list of store endpoints (defaults: 127.0.0.1:2379 for etcd, 127.0.0.1:8500 for consul)")
+	cmdProxy.PersistentFlags().StringVar(&cfg.storeCertFile, "store-cert", "", "path to the client server TLS cert file")
+	cmdProxy.PersistentFlags().StringVar(&cfg.storeKeyFile, "store-key", "", "path to the client server TLS key file")
+	cmdProxy.PersistentFlags().StringVar(&cfg.storeCACertFile, "store-cacert", "", "path to the client server TLS trusted CA key file")
 	cmdProxy.PersistentFlags().StringVar(&cfg.clusterName, "cluster-name", "", "cluster name")
 	cmdProxy.PersistentFlags().StringVar(&cfg.listenAddress, "listen-address", "127.0.0.1", "proxy listening address")
 	cmdProxy.PersistentFlags().StringVar(&cfg.port, "port", "5432", "proxy listening port")
@@ -83,7 +89,13 @@ type ClusterChecker struct {
 func NewClusterChecker(id string, cfg config) (*ClusterChecker, error) {
 	storePath := filepath.Join(common.StoreBasePath, cfg.clusterName)
 
-	kvstore, err := store.NewStore(store.Backend(cfg.storeBackend), cfg.storeEndpoints)
+	kvstore, err := store.NewStore(
+		store.Backend(cfg.storeBackend),
+		cfg.storeEndpoints,
+		cfg.storeCertFile,
+		cfg.storeKeyFile,
+		cfg.storeCACertFile,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create store: %v", err)
 	}

--- a/cmd/sentinel/sentinel.go
+++ b/cmd/sentinel/sentinel.go
@@ -58,6 +58,9 @@ const (
 type config struct {
 	storeBackend            string
 	storeEndpoints          string
+	storeCertFile           string
+	storeKeyFile            string
+	storeCACertFile         string
 	clusterName             string
 	listenAddress           string
 	port                    string
@@ -74,6 +77,9 @@ var cfg config
 func init() {
 	cmdSentinel.PersistentFlags().StringVar(&cfg.storeBackend, "store-backend", "", "store backend type (etcd or consul)")
 	cmdSentinel.PersistentFlags().StringVar(&cfg.storeEndpoints, "store-endpoints", "", "a comma-delimited list of store endpoints (defaults: 127.0.0.1:2379 for etcd, 127.0.0.1:8500 for consul)")
+	cmdSentinel.PersistentFlags().StringVar(&cfg.storeCertFile, "store-cert", "", "path to the client server TLS cert file")
+	cmdSentinel.PersistentFlags().StringVar(&cfg.storeKeyFile, "store-key", "", "path to the client server TLS key file")
+	cmdSentinel.PersistentFlags().StringVar(&cfg.storeCACertFile, "store-cacert", "", "path to the client server TLS trusted CA key file")
 	cmdSentinel.PersistentFlags().StringVar(&cfg.clusterName, "cluster-name", "", "cluster name")
 	cmdSentinel.PersistentFlags().StringVar(&cfg.listenAddress, "listen-address", "localhost", "sentinel listening address")
 	cmdSentinel.PersistentFlags().StringVar(&cfg.port, "port", "6431", "sentinel listening port")
@@ -663,7 +669,13 @@ func NewSentinel(id string, cfg *config, stop chan bool, end chan bool) (*Sentin
 	}
 
 	storePath := filepath.Join(common.StoreBasePath, cfg.clusterName)
-	kvstore, err := store.NewStore(store.Backend(cfg.storeBackend), cfg.storeEndpoints)
+	kvstore, err := store.NewStore(
+		store.Backend(cfg.storeBackend),
+		cfg.storeEndpoints,
+		cfg.storeCertFile,
+		cfg.storeKeyFile,
+		cfg.storeCACertFile,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create store: %v", err)
 	}

--- a/cmd/stolonctl/config_get.go
+++ b/cmd/stolonctl/config_get.go
@@ -55,7 +55,13 @@ func getConfig(e *store.StoreManager) (*cluster.NilConfig, error) {
 func configGet(cmd *cobra.Command, args []string) {
 	storePath := filepath.Join(common.StoreBasePath, cfg.clusterName)
 
-	kvstore, err := store.NewStore(store.Backend(cfg.storeBackend), cfg.storeEndpoints)
+	kvstore, err := store.NewStore(
+		store.Backend(cfg.storeBackend),
+		cfg.storeEndpoints,
+		cfg.storeCertFile,
+		cfg.storeKeyFile,
+		cfg.storeCACertFile,
+	)
 	if err != nil {
 		die("cannot create store: %v", err)
 	}

--- a/cmd/stolonctl/config_patch.go
+++ b/cmd/stolonctl/config_patch.go
@@ -98,7 +98,13 @@ func configPatch(cmd *cobra.Command, args []string) {
 	}
 
 	storePath := filepath.Join(common.StoreBasePath, cfg.clusterName)
-	kvstore, err := store.NewStore(store.Backend(cfg.storeBackend), cfg.storeEndpoints)
+	kvstore, err := store.NewStore(
+		store.Backend(cfg.storeBackend),
+		cfg.storeEndpoints,
+		cfg.storeCertFile,
+		cfg.storeKeyFile,
+		cfg.storeCACertFile,
+	)
 	if err != nil {
 		die("cannot create store: %v", err)
 	}

--- a/cmd/stolonctl/config_replace.go
+++ b/cmd/stolonctl/config_replace.go
@@ -95,7 +95,13 @@ func configReplace(cmd *cobra.Command, args []string) {
 
 	storePath := filepath.Join(common.StoreBasePath, cfg.clusterName)
 
-	kvstore, err := store.NewStore(store.Backend(cfg.storeBackend), cfg.storeEndpoints)
+	kvstore, err := store.NewStore(
+		store.Backend(cfg.storeBackend),
+		cfg.storeEndpoints,
+		cfg.storeCertFile,
+		cfg.storeKeyFile,
+		cfg.storeCACertFile,
+	)
 	if err != nil {
 		die("cannot create store: %v", err)
 	}

--- a/cmd/stolonctl/listclusters.go
+++ b/cmd/stolonctl/listclusters.go
@@ -36,7 +36,14 @@ func init() {
 }
 
 func getClusters(storeBasePath string) ([]string, error) {
-	kvstore, err := store.NewStore(store.Backend(cfg.storeBackend), cfg.storeEndpoints)
+	kvstore, err := store.NewStore(
+		store.Backend(cfg.storeBackend),
+		cfg.storeEndpoints,
+		cfg.storeCertFile,
+		cfg.storeKeyFile,
+		cfg.storeCACertFile,
+	)
+
 	if err != nil {
 		return nil, fmt.Errorf("cannot create store: %v", err)
 	}

--- a/cmd/stolonctl/status.go
+++ b/cmd/stolonctl/status.go
@@ -84,7 +84,13 @@ func status(cmd *cobra.Command, args []string) {
 	}
 	storePath := filepath.Join(common.StoreBasePath, cfg.clusterName)
 
-	kvstore, err := store.NewStore(store.Backend(cfg.storeBackend), cfg.storeEndpoints)
+	kvstore, err := store.NewStore(
+		store.Backend(cfg.storeBackend),
+		cfg.storeEndpoints,
+		cfg.storeCertFile,
+		cfg.storeKeyFile,
+		cfg.storeCACertFile,
+	)
 	if err != nil {
 		die("cannot create store: %v", err)
 	}

--- a/cmd/stolonctl/stolonctl.go
+++ b/cmd/stolonctl/stolonctl.go
@@ -38,9 +38,12 @@ var cmdStolonCtl = &cobra.Command{
 }
 
 type config struct {
-	storeBackend   string
-	storeEndpoints string
-	clusterName    string
+	storeBackend    string
+	storeEndpoints  string
+	storeCertFile   string
+	storeKeyFile    string
+	storeCACertFile string
+	clusterName     string
 }
 
 var cfg config
@@ -48,6 +51,9 @@ var cfg config
 func init() {
 	cmdStolonCtl.PersistentFlags().StringVar(&cfg.storeBackend, "store-backend", "", "store backend type (etcd or consul)")
 	cmdStolonCtl.PersistentFlags().StringVar(&cfg.storeEndpoints, "store-endpoints", "", "a comma-delimited list of store endpoints (defaults: 127.0.0.1:2379 for etcd, 127.0.0.1:8500 for consul)")
+	cmdStolonCtl.PersistentFlags().StringVar(&cfg.storeCertFile, "store-cert", "", "path to the client server TLS cert file")
+	cmdStolonCtl.PersistentFlags().StringVar(&cfg.storeKeyFile, "store-key", "", "path to the client server TLS key file")
+	cmdStolonCtl.PersistentFlags().StringVar(&cfg.storeCACertFile, "store-cacert", "", "path to the client server TLS trusted CA key file")
 	cmdStolonCtl.PersistentFlags().StringVar(&cfg.clusterName, "cluster-name", "", "cluster name")
 }
 

--- a/tests/integration/config_test.go
+++ b/tests/integration/config_test.go
@@ -53,7 +53,13 @@ func TestServerParameters(t *testing.T) {
 
 	storePath := filepath.Join(common.StoreBasePath, clusterName)
 
-	kvstore, err := store.NewStore(tstore.storeBackend, storeEndpoints)
+	kvstore, err := store.NewStore(
+		tstore.storeBackend,
+		storeEndpoints,
+		"",
+		"",
+		"",
+	)
 	if err != nil {
 		t.Fatalf("cannot create store: %v", err)
 	}

--- a/tests/integration/ha_test.go
+++ b/tests/integration/ha_test.go
@@ -67,7 +67,13 @@ func TestInitWithMultipleKeepers(t *testing.T) {
 
 	storePath := filepath.Join(common.StoreBasePath, clusterName)
 
-	kvstore, err := store.NewStore(tstore.storeBackend, storeEndpoints)
+	kvstore, err := store.NewStore(
+		tstore.storeBackend,
+		storeEndpoints,
+		"",
+		"",
+		"",
+	)
 	if err != nil {
 		t.Fatalf("cannot create store: %v", err)
 	}
@@ -131,7 +137,13 @@ func setupServers(t *testing.T, clusterName, dir string, numKeepers, numSentinel
 
 	storePath := filepath.Join(common.StoreBasePath, clusterName)
 
-	kvstore, err := store.NewStore(tstore.storeBackend, storeEndpoints)
+	kvstore, err := store.NewStore(
+		tstore.storeBackend,
+		storeEndpoints,
+		"",
+		"",
+		"",
+	)
 	if err != nil {
 		t.Fatalf("cannot create store: %v", err)
 	}

--- a/tests/integration/init_test.go
+++ b/tests/integration/init_test.go
@@ -118,7 +118,13 @@ func TestInitUsers(t *testing.T) {
 	clusterName = uuid.NewV4().String()
 	storePath := filepath.Join(common.StoreBasePath, clusterName)
 
-	kvstore, err := store.NewStore(tstore.storeBackend, storeEndpoints)
+	kvstore, err := store.NewStore(
+		tstore.storeBackend,
+		storeEndpoints,
+		"",
+		"",
+		"",
+	)
 	if err != nil {
 		t.Fatalf("cannot create store: %v", err)
 	}
@@ -154,7 +160,13 @@ func TestInitUsers(t *testing.T) {
 	clusterName = uuid.NewV4().String()
 	storePath = filepath.Join(common.StoreBasePath, clusterName)
 
-	kvstore, err = store.NewStore(tstore.storeBackend, storeEndpoints)
+	kvstore, err = store.NewStore(
+		tstore.storeBackend,
+		storeEndpoints,
+		"",
+		"",
+		"",
+	)
 	if err != nil {
 		t.Fatalf("cannot create store: %v", err)
 	}
@@ -216,7 +228,13 @@ func TestInitialClusterConfig(t *testing.T) {
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 	storePath := filepath.Join(common.StoreBasePath, clusterName)
 
-	kvstore, err := store.NewStore(tstore.storeBackend, storeEndpoints)
+	kvstore, err := store.NewStore(
+		tstore.storeBackend,
+		storeEndpoints,
+		"",
+		"",
+		"",
+	)
 	if err != nil {
 		t.Fatalf("cannot create store: %v", err)
 	}

--- a/tests/integration/proxy_test.go
+++ b/tests/integration/proxy_test.go
@@ -77,7 +77,13 @@ func TestProxyListening(t *testing.T) {
 
 	storePath := filepath.Join(common.StoreBasePath, clusterName)
 
-	kvstore, err := store.NewStore(tstore.storeBackend, storeEndpoints)
+	kvstore, err := store.NewStore(
+		tstore.storeBackend,
+		storeEndpoints,
+		"",
+		"",
+		"",
+	)
 	if err != nil {
 		t.Fatalf("cannot create store: %v", err)
 	}

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -603,7 +603,13 @@ func NewTestEtcd(t *testing.T, dir string, a ...string) (*TestStore, error) {
 
 	storeEndpoints := fmt.Sprintf("%s:%s", listenAddress, port)
 
-	kvstore, err := store.NewStore(store.ETCD, storeEndpoints)
+	kvstore, err := store.NewStore(
+		store.ETCD,
+		storeEndpoints,
+		"",
+		"",
+		"",
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create store: %v", err)
 	}
@@ -685,7 +691,13 @@ func NewTestConsul(t *testing.T, dir string, a ...string) (*TestStore, error) {
 
 	storeEndpoints := fmt.Sprintf("%s:%s", listenAddress, portHTTP)
 
-	kvstore, err := store.NewStore(store.CONSUL, storeEndpoints)
+	kvstore, err := store.NewStore(
+		store.CONSUL,
+		storeEndpoints,
+		"",
+		"",
+		"",
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create store: %v", err)
 	}


### PR DESCRIPTION
Add capability to use TLS for communication with store, for example with [secure etcd](https://coreos.com/etcd/docs/latest/security.html)

Integration tests are not in scope of this PR, it will be done separately

You can check it out manually by using following steps:
- Rebuild stolon bins from this branch
- Quickly setup secure etcd using [this tool](https://github.com/coreos/etcd/tree/master/hack/tls-setup)
- Run stolon bins using proper values to flags, like:

```
$ cat Procfile 
sentinel: ./bin/stolon-sentinel --cluster-name stolon-cluster --store-backend etcd --store-endpoints localhost:8080 --store-cert $GOPATH/src/github.com/coreos/etcd/hack/tls-setup/certs/proxy1.pem --store-key $GOPATH/src/github.com/coreos/etcd/hack/tls-setup/certs/proxy1-key.pem --store-cacert $GOPATH/src/github.com/coreos/etcd/hack/tls-setup/certs/ca.pem
keeper0: ./bin/stolon-keeper --data-dir data/postgres0 --id postgres0 --cluster-name stolon-cluster --pg-repl-username repluser --pg-repl-password replpassword --pg-su-username postgres --pg-su-password qweqwe --pg-bin-path /usr/lib/postgresql/9.4/bin --store-backend etcd --store-endpoints localhost:8080 --store-cert $GOPATH/src/github.com/coreos/etcd/hack/tls-setup/certs/proxy1.pem --store-key $GOPATH/src/github.com/coreos/etcd/hack/tls-setup/certs/proxy1-key.pem --store-cacert $GOPATH/src/github.com/coreos/etcd/hack/tls-setup/certs/ca.pem
proxy: ./bin/stolon-proxy --cluster-name stolon-cluster --port 25432 --store-backend etcd --store-endpoints localhost:8080 --store-cert $GOPATH/src/github.com/coreos/etcd/hack/tls-setup/certs/proxy1.pem --store-key $GOPATH/src/github.com/coreos/etcd/hack/tls-setup/certs/proxy1-key.pem --store-cacert $GOPATH/src/github.com/coreos/etcd/hack/tls-setup/certs/ca.pem
```
