### PR TITLE
Add no password flag

### DIFF
--- a/cmd/stolonctl/database/database.go
+++ b/cmd/stolonctl/database/database.go
@@ -58,7 +58,7 @@ func backupToFile(conn ConnSettings, dbName, dest string) error {
 		"--file", dest,
 		"--compress", "6",
 		"--format", "custom",
-		dbName)
+		"--no-password", dbName)
 	out, err := cmd.CombinedOutput()
 	if len(out) > 0 {
 		log.Infof("cmd output: %s", string(out))
@@ -99,7 +99,7 @@ func restoreFromFile(conn ConnSettings, src string) error {
 		"--host", conn.Host,
 		"--port", conn.Port,
 		"--username", conn.Username,
-		src)
+		"--no-password", src)
 	out, err := cmd.CombinedOutput()
 	if len(out) > 0 {
 		log.Infof("cmd output: %s", string(out))


### PR DESCRIPTION
From man

```
--no-password
           Never issue a password prompt. If the server requires password authentication and a password is not available by other means such as a .pgpass file, the connection
           attempt will fail. This option can be useful in batch jobs and scripts where no user is present to enter a password.
```
