### PR TITLE
pass management db to psql

### DIFF
--- a/cmd/stolonctl/database/database.go
+++ b/cmd/stolonctl/database/database.go
@@ -184,7 +184,7 @@ func basePsqlCommand(conn ConnSettings, args ...string) *exec.Cmd {
 		"--host", conn.Host,
 		"--port", conn.Port,
 		"--username", conn.Username,
-		"--no-password",
+		"--no-password", "postgres",
 	}
 	connArgs = append(connArgs, args...)
 	return psqlCommand(connArgs...)


### PR DESCRIPTION
`psql` needs database as an argument. This bug blocks `create db` and `delete db` commands. This PR is quick fix for that problem.

Another way is to use `createdb` and `dropdb` utils from PG bin folder. To use this we need to pass path for pg_bin as it done in keeper, because it's hidden ( not in PATH). It can be done in another PR.
