### PR TITLE
Changed default value for wal_keep_segments

### DIFF
--- a/cmd/keeper/keeper.go
+++ b/cmd/keeper/keeper.go
@@ -126,7 +126,7 @@ func init() {
 var defaultPGParameters = pg.Parameters{
 	"unix_socket_directories": "/tmp",
 	"wal_level":               "hot_standby",
-	"wal_keep_segments":       "8",
+	"wal_keep_segments":       "128",
 	"hot_standby":             "on",
 	"max_connections":         "500",
 }


### PR DESCRIPTION
New value can help with big replication lag. But not more than
(128+3+1)*16MB.