### PR TITLE
Detect differing systemid and resync

### DIFF
--- a/cmd/keeper/keeper.go
+++ b/cmd/keeper/keeper.go
@@ -630,6 +630,11 @@ func (p *PostgresKeeper) resync(followed *cluster.KeeperState, initialized, star
 }
 
 func (p *PostgresKeeper) isDifferentTimelineBranch(fPGState *cluster.PostgresState, pgState *cluster.PostgresState) bool {
+	if fPGState.SystemID != pgState.SystemID {
+		log.Infof("followed instance system ID %d different than our system ID %d", fPGState.SystemID, pgState.SystemID)
+		return true
+	}
+
 	if fPGState.TimelineID < pgState.TimelineID {
 		log.Infof("followed instance timeline %d < than our timeline %d", fPGState.TimelineID, pgState.TimelineID)
 		return true

--- a/cmd/sentinel/sentinel.go
+++ b/cmd/sentinel/sentinel.go
@@ -235,6 +235,10 @@ func (s *Sentinel) GetBestStandby(cv *cluster.ClusterView, keepersState cluster.
 			log.Warningf("ignoring node since its pg state is unknown")
 			continue
 		}
+		if masterState.PGState.SystemID != k.PGState.SystemID {
+			log.Warningf("ignoring node since it's system ID (%s) is different than the master system ID (%s)", k.PGState.SystemID, masterState.PGState.TimelineID)
+			continue
+		}
 		if masterState.PGState.TimelineID != k.PGState.TimelineID {
 			log.Warningf("ignoring node since its pg timeline (%s) is different than master timeline (%d)", keepersState[id].PGState.TimelineID, masterState.PGState.TimelineID)
 			continue


### PR DESCRIPTION
Multiple keepers can initialize themselves as master initially, in the absence of a cluster quorum. After that, they will never correctly follow an elected master, because they will have differing system IDs. The root cause of this is the rather simple `IsInitialized` check. It's not clear why this ever worked -- a keeper reporting itself as initialized will never resync. Still investigating.