### PR TITLE
Resynchronize standbys if there are no ready

### DIFF
--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -171,7 +171,7 @@ func (p *Manager) Start() error {
 	}
 	name := filepath.Join(p.pgBinPath, "pg_ctl")
 	cmd := exec.Command(name, "start", "-w", "-t",
-		string(startTimeout/time.Minute), "-D", p.dataDir)
+		string(startTimeout/time.Second), "-D", p.dataDir)
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		return trace.Wrap(err)
@@ -181,6 +181,7 @@ func (p *Manager) Start() error {
 		return trace.Wrap(err)
 	}
 
+	log.Infof("Executing command: %s", cmd.String())
 	if err = cmd.Start(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -171,7 +172,7 @@ func (p *Manager) Start() error {
 	}
 	name := filepath.Join(p.pgBinPath, "pg_ctl")
 	cmd := exec.Command(name, "start", "-w", "-t",
-		string(int64(startTimeout/time.Second)), "-D", p.dataDir)
+		strconv.FormatInt(int64(startTimeout/time.Second), 10), "-D", p.dataDir)
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		return trace.Wrap(err)

--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -171,7 +171,7 @@ func (p *Manager) Start() error {
 	}
 	name := filepath.Join(p.pgBinPath, "pg_ctl")
 	cmd := exec.Command(name, "start", "-w", "-t",
-		string(startTimeout/time.Second), "-D", p.dataDir)
+		string(int64(startTimeout/time.Second)), "-D", p.dataDir)
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This PR fixes a situation when after master failover, the required WAL for standby does not exist on the new master.